### PR TITLE
Replace SuperGlue code with OpenGlue code (MIT)

### DIFF
--- a/models/aggregators/salad.py
+++ b/models/aggregators/salad.py
@@ -1,3 +1,4 @@
+import math
 import torch
 import torch.nn as nn
 


### PR DESCRIPTION
The repo is GPL-3 licensed, but contains non-commercial code from SuperGlue.
I have replaced it with independent reimplementation from [OpenGlue](https://github.com/ucuapps/OpenGlue), which does the same thing
