### PR TITLE
Make some dependencies optional for inference

### DIFF
--- a/utils/losses.py
+++ b/utils/losses.py
@@ -1,7 +1,7 @@
-from pytorch_metric_learning import losses, miners
-from pytorch_metric_learning.distances import CosineSimilarity, DotProductSimilarity
-
 def get_loss(loss_name):
+    from pytorch_metric_learning import losses
+    from pytorch_metric_learning.distances import DotProductSimilarity
+
     if loss_name == 'SupConLoss': return losses.SupConLoss(temperature=0.07)
     if loss_name == 'CircleLoss': return losses.CircleLoss(m=0.4, gamma=80) #these are params for image retrieval
     if loss_name == 'MultiSimilarityLoss': return losses.MultiSimilarityLoss(alpha=1.0, beta=50, base=0.0, distance=DotProductSimilarity())
@@ -17,6 +17,9 @@ def get_loss(loss_name):
     raise NotImplementedError(f'Sorry, <{loss_name}> loss function is not implemented!')
 
 def get_miner(miner_name, margin=0.1):
+    from pytorch_metric_learning import miners
+    from pytorch_metric_learning.distances import CosineSimilarity, DotProductSimilarity
+
     if miner_name == 'TripletMarginMiner' : return miners.TripletMarginMiner(margin=margin, type_of_triplets="semihard") # all, hard, semihard, easy
     if miner_name == 'MultiSimilarityMiner' : return miners.MultiSimilarityMiner(epsilon=margin, distance=CosineSimilarity())
     if miner_name == 'PairMarginMiner' : return miners.PairMarginMiner(pos_margin=0.7, neg_margin=0.3, distance=DotProductSimilarity())

--- a/utils/validation.py
+++ b/utils/validation.py
@@ -1,11 +1,11 @@
 import numpy as np
-import faiss
-import faiss.contrib.torch_utils
-from prettytable import PrettyTable
 
 
 def get_validation_recalls(r_list, q_list, k_values, gt, print_results=True, faiss_gpu=False, dataset_name='dataset without name ?', testing=False):
-        
+        import faiss
+        import faiss.contrib.torch_utils
+        from prettytable import PrettyTable
+
         embed_size = r_list.shape[1]
         if faiss_gpu:
             res = faiss.StandardGpuResources()
@@ -16,16 +16,16 @@ def get_validation_recalls(r_list, q_list, k_values, gt, print_results=True, fai
         # build index
         else:
             faiss_index = faiss.IndexFlatL2(embed_size)
-        
+
         # add references
         faiss_index.add(r_list)
 
         # search for queries in the index
         _, predictions = faiss_index.search(q_list, max(k_values))
-        
+
         if testing:
             return predictions
-        
+
         # start calculating recall_at_k
         correct_at_k = np.zeros(len(k_values))
         for q_idx, pred in enumerate(predictions):
@@ -34,7 +34,7 @@ def get_validation_recalls(r_list, q_list, k_values, gt, print_results=True, fai
                 if np.any(np.in1d(pred[:n], gt[q_idx])):
                     correct_at_k[i:] += 1
                     break
-        
+
         correct_at_k = correct_at_k / len(predictions)
         d = {k:v for (k,v) in zip(k_values, correct_at_k)}
 
@@ -44,5 +44,5 @@ def get_validation_recalls(r_list, q_list, k_values, gt, print_results=True, fai
             table.field_names = ['K']+[str(k) for k in k_values]
             table.add_row(['Recall@K']+ [f'{100*v:.2f}' for v in correct_at_k])
             print(table.get_string(title=f"Performances on {dataset_name}"))
-        
+
         return d


### PR DESCRIPTION
The torch hub endpoint forces users to install pytorch_metric_learning and faiss even though they are not used during inference.